### PR TITLE
X32 cleanup

### DIFF
--- a/plugins/x32/main.js
+++ b/plugins/x32/main.js
@@ -56,7 +56,7 @@ function convertToDBTheBehringerWay(f) {
 exports.data = function data(device, buf) {
   this.deviceInfoUpdate(device, 'status', 'ok');
 
-  //replace one or more nulls with new line then split on that
+  // replace one or more nulls with new line then split on that
   const msg = buf.toString().replace(/(\0+)/gm, '\n').split('\n');
 
   const d = device;

--- a/plugins/x32/main.js
+++ b/plugins/x32/main.js
@@ -6,7 +6,7 @@ exports.searchOptions = {
   searchBuffer: Buffer.from([0x2f, 0x78, 0x69, 0x6e, 0x66, 0x6f]),
   devicePort: 10023,
   listenPort: 0,
-  validateResponse (msg, info) {
+  validateResponse(msg, info) {
     return msg.toString().indexOf('/xinfo') === 0;
   },
 };
@@ -23,7 +23,7 @@ exports.ready = function ready(device) {
   d.data.stereoFader = 0;
   d.data.stereoFaderDB = 0;
   d.data.stereoMute = 0;
-  d.data.stereoName = "LR";
+  d.data.stereoName = 'LR';
   d.data.stereoColor = 7;
 
   d.send(Buffer.from('/xinfo'));
@@ -93,9 +93,7 @@ exports.data = function data(device, buf) {
       );
     } else if (addr[0] === 'main') {
       d.data.stereoFader = buf.readFloatBE(24);
-      d.data.stereoFaderDB = convertToDBTheBehringerWay(
-        buf.readFloatBE(24)
-      );
+      d.data.stereoFaderDB = convertToDBTheBehringerWay(buf.readFloatBE(24));
     }
 
     d.draw();
@@ -105,30 +103,25 @@ exports.data = function data(device, buf) {
 
     if (addr[0] === 'ch') {
       d.data.channelMutes[channel - 1] = buf[23];
-      d.send(
-        Buffer.from(`/ch/${addr[1]}/mix/fader\u0000\u0000\u0000\u0000`)
-      );
+      d.send(Buffer.from(`/ch/${addr[1]}/mix/fader\u0000\u0000\u0000\u0000`));
     } else if (addr[0] === 'main') {
-      d.data.stereoMute = buf.slice(-1)[0] ;
-      d.send(
-        Buffer.from(`/main/${addr[1]}/mix/fader\u0000\u0000\u0000\u0000`)
-      );
+      d.data.stereoMute = buf.slice(-1)[0];
+      d.send(Buffer.from(`/main/${addr[1]}/mix/fader\u0000\u0000\u0000\u0000`));
     }
     d.draw();
-    
   } else if (msg[0].indexOf('/config/name') > 0) {
     const addr = parseAddress(msg[0]);
-    if(addr[0] === "main"){
-      if(addr[1] === "st"){
-        d.data.stereoName = msg[2]
-        if(d.data.stereoName === ""){
-          d.data.stereoName = "LR";
+    if (addr[0] === 'main') {
+      if (addr[1] === 'st') {
+        d.data.stereoName = msg[2];
+        if (d.data.stereoName === '') {
+          d.data.stereoName = 'LR';
         }
         d.send(
           Buffer.from(`/main/${addr[1]}/config/color\u0000\u0000\u0000\u0000`)
         );
       }
-    } else if (addr[0] === "ch"){
+    } else if (addr[0] === 'ch') {
       const channel = Number(addr[1]);
       d.data.channelNames[channel - 1] = msg[2];
       d.send(
@@ -138,11 +131,10 @@ exports.data = function data(device, buf) {
     d.draw();
   } else if (msg[0].indexOf('/config/color') > 0) {
     const addr = parseAddress(msg[0]);
-    if (addr[0] === "main"){
+    if (addr[0] === 'main') {
       d.data.stereoColor = Buffer.from(msg[2]).readInt8();
       d.send(Buffer.from(`/main/${addr[1]}/mix/on\u0000\u0000\u0000\u0000`));
-      
-    } else if (addr[0] === "ch"){
+    } else if (addr[0] === 'ch') {
       const channel = Number(addr[1]);
       d.data.channelColors[channel - 1] = buf.readInt8(27);
       d.send(Buffer.from(`/ch/${addr[1]}/mix/on\u0000\u0000\u0000\u0000`));

--- a/plugins/x32/styles.css
+++ b/plugins/x32/styles.css
@@ -133,3 +133,24 @@ input[type='range']::-webkit-slider-runnable-track {
   font-size: 20px;
   vertical-align: middle;
 }
+
+.meter {
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    rgba(19, 126, 30, 1) 0%,
+    rgba(255, 238, 30, 1) 85%,
+    rgba(255, 0, 0, 1) 100%
+  );
+}
+
+/* need to find a way to match the color of this with the table row */
+.meter-cover {
+  height: 100%;
+  background-color: rgb(22, 23, 25);
+  float: right;
+}
+
+table.cv-table tr:nth-child(odd) td div.meter div.meter-cover {
+  background-color: #292929;
+}

--- a/plugins/x32/styles.css
+++ b/plugins/x32/styles.css
@@ -129,7 +129,7 @@ input[type='range']::-webkit-slider-runnable-track {
   border-radius: 4px;
 }
 
-.infin{
+.infin {
   font-size: 20px;
   vertical-align: middle;
 }

--- a/plugins/x32/styles.css
+++ b/plugins/x32/styles.css
@@ -128,3 +128,8 @@ input[type='range']::-webkit-slider-runnable-track {
   background: #3b3b3b;
   border-radius: 4px;
 }
+
+.infin{
+  font-size: 20px;
+  vertical-align: middle;
+}

--- a/plugins/x32/template.ejs
+++ b/plugins/x32/template.ejs
@@ -13,30 +13,15 @@
   </tr>
   <tr>
     <td width="40px">LR</td>
-    <td width="100px"><div class="color color-<%= data.stereoColor %>"><%- data.stereoName%></div></td>
-    <td><div class="fader-mute mute-<%=data.stereoMute%>">M</div></td>
-    <td><%= formatAsDB(data.stereoFaderDB) %></td>
+    <td width="100px"><div class="color color-<%= data.X32.main.stereo.color %>"><%- data.X32.main.stereo.name%></div></td>
+    <td><div class="fader-mute mute-<%=data.X32.main.stereo.mute%>">M</div></td>
+    <td><%= formatAsDB(data.X32.main.stereo.faderDB) %></td>
     <td>
-      <input
-        type="range"
-        min="0"
-        max="100"
-        value="<%= data.stereoFader*100 %>"
-        disabled />
-    </td>
-  </tr>
-  <% for(var i=0; i<32; i++){ %> <% if(data.channelNames[i]=="end"){break;} %>
-  <tr>
-    <td><%= i+1 %></td>
-    <td>
-      <div class="color color-<%= data.channelColors[i] %>">
-        <%- data.channelNames[i] || i+1 %>
+      <% let style = `style=width:${Math.abs(data.X32.main.stereo.meter[0] - 10)}%`; %>
+      <div class="meter">
+        <div class="meter-cover" <%= style %>></div>
       </div>
-    </td>
-    <td><div class="fader-mute mute-<%=data.channelMutes[i]%>">M</div></td>
-    <td><%= formatAsDB(data.channelFadersDB[i]) %></td>
-    <td>
-      <% let style = `style=width:${Math.abs(data.meters[i] - 10)}%`; %>
+      <% style = `style=width:${Math.abs(data.X32.main.stereo.meter[1] - 10)}%`; %>
       <div class="meter">
         <div class="meter-cover" <%= style %>></div>
       </div>
@@ -44,7 +29,30 @@
         type="range"
         min="0"
         max="100"
-        value="<%= data.channelFaders[i]*100 %>"
+        value="<%= data.X32.main.stereo.fader*100 %>"
+        disabled />
+    </td>
+  </tr>
+  <% for(var i=0; i<32; i++){ %> <% if(data.X32.inputs.channels[i].name == "end"){break;} %>
+  <tr>
+    <td><%= i+1 %></td>
+    <td>
+      <div class="color color-<%= data.X32.inputs.channels[i].color %>">
+        <%- data.X32.inputs.channels[i].name || i+1 %>
+      </div>
+    </td>
+    <td><div class="fader-mute mute-<%=data.X32.inputs.channels[i].mute%>">M</div></td>
+    <td><%= formatAsDB(data.X32.inputs.channels[i].faderDB) %></td>
+    <td>
+      <% let style = `style=width:${Math.abs(data.X32.inputs.channels[i].meter - 10)}%`; %>
+      <div class="meter">
+        <div class="meter-cover" <%= style %>></div>
+      </div>
+      <input
+        type="range"
+        min="0"
+        max="100"
+        value="<%= data.X32.inputs.channels[i].fader*100 %>"
         disabled />
     </td>
   </tr>

--- a/plugins/x32/template.ejs
+++ b/plugins/x32/template.ejs
@@ -36,6 +36,8 @@
     <td><div class="fader-mute mute-<%=data.channelMutes[i]%>">M</div></td>
     <td><%= formatAsDB(data.channelFadersDB[i]) %></td>
     <td>
+      <% let style = `style=height:3px;background-color:green;width:${data.meters[i] + 90}%`; %>
+      <div <%= style %>></div>
       <input
         type="range"
         min="0"

--- a/plugins/x32/template.ejs
+++ b/plugins/x32/template.ejs
@@ -36,8 +36,10 @@
     <td><div class="fader-mute mute-<%=data.channelMutes[i]%>">M</div></td>
     <td><%= formatAsDB(data.channelFadersDB[i]) %></td>
     <td>
-      <% let style = `style=height:3px;background-color:green;width:${data.meters[i] + 90}%`; %>
-      <div <%= style %>></div>
+      <% let style = `style=width:${Math.abs(data.meters[i] - 10)}%`; %>
+      <div class="meter">
+        <div class="meter-cover" <%= style %>></div>
+      </div>
       <input
         type="range"
         min="0"

--- a/plugins/x32/template.ejs
+++ b/plugins/x32/template.ejs
@@ -13,9 +13,9 @@
   </tr>
   <tr>
     <td width="40px">LR</td>
-    <td width="100px"><div class="color color-8">MAIN OUT</div></td>
+    <td width="100px"><div class="color color-<%= data.stereoColor %>"><%- data.stereoName%></div></td>
     <td><div class="fader-mute mute-<%=data.stereoMute%>">M</div></td>
-    <td><%- formatAsDB(data.stereoFaderDB) %></td>
+    <td><%= formatAsDB(data.stereoFaderDB) %></td>
     <td>
       <input
         type="range"
@@ -34,7 +34,7 @@
       </div>
     </td>
     <td><div class="fader-mute mute-<%=data.channelMutes[i]%>">M</div></td>
-    <td><%- formatAsDB(data.channelFadersDB[i]) %></td>
+    <td><%= formatAsDB(data.channelFadersDB[i]) %></td>
     <td>
       <input
         type="range"
@@ -47,5 +47,5 @@
   <% } %>
 </table>
 
-<% function formatAsDB(val){ if(val==-90){ return "-&infin;"; } if(val>0){
+<% function formatAsDB(val){ if(val==-90){ return '-<span class="infin">&infin;</span>'; } if(val>0){
 return "+"+val.toFixed(1); } return val.toFixed(1); } %>

--- a/plugins/xair/main.js
+++ b/plugins/xair/main.js
@@ -28,7 +28,6 @@ exports.ready = function ready(device) {
 
   // device.send(Buffer.from("\x2f\x62\x61\x74\x63\x68\x73\x75\x62\x73\x63\x72\x69\x62\x65\x00\x2c\x73\x73\x69\x69\x69\x00\x00\x6d\x65\x74\x65\x72\x73\x2f\x30\x00\x00\x00\x00\x2f\x6d\x65\x74\x65\x72\x73\x2f\x30\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01"));
   // device.send(Buffer.from("/batchsubscribe\x00,ssiii\x00\x00meters/0\x00\x00\x00\x00/meters/0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01"));
-
   // device.send(Buffer.from("/subscribe\x00,si\x00/-stat/solosw/01\x001"));
 };
 
@@ -53,7 +52,7 @@ function convertToDBTheBehringerWay(f) {
 
 exports.data = function data(device, buf) {
   this.deviceInfoUpdate(device, 'status', 'ok');
-  const msg = buf.toString().split('\u0000');
+  const msg = buf.toString().split('\x00');
   const d = device;
 
   if (msg[0] === '/xinfo') {
@@ -68,15 +67,13 @@ exports.data = function data(device, buf) {
     d.data.model = msg[9];
     this.deviceInfoUpdate(d, 'defaultName', d.data.name);
 
-    d.send('/lr/mix/fader\u0000\u0000\u0000\u0000');
-    d.send('/lr/mix/on\u0000\u0000\u0000\u0000');
+    d.send('/lr/mix/fader\x00\x00\x00\x00');
+    d.send('/lr/mix/on\x00\x00\x00\x00');
 
     for (let i = 0; i <= 32; i++) {
       d.send(
         Buffer.from(
-          `/ch/${i
-            .toString()
-            .padStart(2, '0')}/config/name\u0000\u0000\u0000\u0000`
+          `/ch/${i.toString().padStart(2, '0')}/config/name\x00\x00\x00\x00`
         )
       );
     }
@@ -108,19 +105,19 @@ exports.data = function data(device, buf) {
       d.data.stereoMute = buf[19];
     }
     device.draw();
-    device.send(`/ch/${addr[1]}/mix/fader\u0000\u0000\u0000\u0000`);
+    device.send(`/ch/${addr[1]}/mix/fader\x00\x00\x00\x00`);
   } else if (msg[0].indexOf('/config/name') > 0) {
     const addr = parseAddress(msg[0]);
     const channel = Number(addr[1]);
     d.data.channelNames[channel - 1] = msg[4];
     d.draw();
-    d.send(`/ch/${addr[1]}/config/color\u0000\u0000\u0000\u0000`);
+    d.send(`/ch/${addr[1]}/config/color\x00\x00\x00\x00`);
   } else if (msg[0].indexOf('/config/color') > 0) {
     const addr = parseAddress(msg[0]);
     const channel = Number(addr[1]);
     d.data.channelColors[channel - 1] = buf.readInt8(27);
     d.draw();
-    d.send(`/ch/${addr[1]}/mix/on\u0000\u0000\u0000\u0000`);
+    d.send(`/ch/${addr[1]}/mix/on\x00\x00\x00\x00`);
   } else {
     // console.log(msg)
   }

--- a/plugins/xair/main.js
+++ b/plugins/xair/main.js
@@ -6,7 +6,7 @@ exports.searchOptions = {
   searchBuffer: Buffer.from([0x2f, 0x78, 0x69, 0x6e, 0x66, 0x6f]),
   devicePort: 10024,
   listenPort: 0,
-  validateResponse (msg, info) {
+  validateResponse(msg, info) {
     return msg.toString().indexOf('/xinfo') === 0;
   },
 };
@@ -81,7 +81,6 @@ exports.data = function data(device, buf) {
       );
     }
     d.draw();
-
   } else if (msg[0] === '/meters/0') {
     // console.log(msg)
   } else if (msg[0].indexOf('/mix/fader') >= 0) {
@@ -95,13 +94,10 @@ exports.data = function data(device, buf) {
       );
     } else if (addr[0] === 'lr') {
       d.data.stereoFader = buf.readFloatBE(20);
-      d.data.stereoFaderDB = convertToDBTheBehringerWay(
-        buf.readFloatBE(20)
-      );
+      d.data.stereoFaderDB = convertToDBTheBehringerWay(buf.readFloatBE(20));
     }
 
     d.draw();
-
   } else if (msg[0].indexOf('/mix/on') >= 0) {
     const addr = parseAddress(msg[0]);
     const channel = Number(addr[1]);
@@ -113,21 +109,18 @@ exports.data = function data(device, buf) {
     }
     device.draw();
     device.send(`/ch/${addr[1]}/mix/fader\u0000\u0000\u0000\u0000`);
-
   } else if (msg[0].indexOf('/config/name') > 0) {
     const addr = parseAddress(msg[0]);
     const channel = Number(addr[1]);
     d.data.channelNames[channel - 1] = msg[4];
     d.draw();
     d.send(`/ch/${addr[1]}/config/color\u0000\u0000\u0000\u0000`);
-
   } else if (msg[0].indexOf('/config/color') > 0) {
     const addr = parseAddress(msg[0]);
     const channel = Number(addr[1]);
     d.data.channelColors[channel - 1] = buf.readInt8(27);
     d.draw();
     d.send(`/ch/${addr[1]}/mix/on\u0000\u0000\u0000\u0000`);
-
   } else {
     // console.log(msg)
   }

--- a/plugins/xair/styles.css
+++ b/plugins/xair/styles.css
@@ -127,3 +127,8 @@ input[type='range']::-webkit-slider-runnable-track {
   background: #3b3b3b;
   border-radius: 4px;
 }
+
+.infin{
+  font-size: 20px;
+  vertical-align: middle;
+}

--- a/plugins/xair/template.ejs
+++ b/plugins/xair/template.ejs
@@ -15,7 +15,7 @@
     <td width="40px">LR</td>
     <td width="100px"><div class="color color-8">MAIN OUT</div></td>
     <td><div class="fader-mute mute-<%=data.stereoMute%>">M</div></td>
-    <td><%- formatAsDB(data.stereoFaderDB) %></td>
+    <td><%= formatAsDB(data.stereoFaderDB) %></td>
     <td>
       <input
         type="range"
@@ -34,7 +34,7 @@
       </div>
     </td>
     <td><div class="fader-mute mute-<%=data.channelMutes[i]%>">M</div></td>
-    <td><%- formatAsDB(data.channelFadersDB[i]) %></td>
+    <td><%= formatAsDB(data.channelFadersDB[i]) %></td>
     <td>
       <input
         type="range"
@@ -47,5 +47,5 @@
   <% } %>
 </table>
 
-<% function formatAsDB(val){ if(val==-90){ return "-&infin;"; } if(val>0){
+<% function formatAsDB(val){ if(val==-90){ return '-<span class="infin">&infin;</span>'; } if(val>0){
 return "+"+val.toFixed(1); } return val.toFixed(1); } %>


### PR DESCRIPTION
Fixed the inif symbol displayig `-&infin;` instead of `-∞` this 

- `/ch/lr` isn't a thing in the x32/m32 osc (maybe is with xair I don't have one anymore so can't test) as far as I can tell it is `/main/st` and `/main/m` for the stereo and mono channels so I added that in
- Added fetching of the main stereo name and color and added that to the template (it seems backwards as far as the color inversion looks but I will test some more).