### PR TITLE
Add frame to window on mac app

### DIFF
--- a/main.js
+++ b/main.js
@@ -151,9 +151,7 @@ const menuTemplate = [
 const windowMac = {
   width: 1500,
   height: 900,
-  titleBarStyle: 'customButtonsOnHover',
   transparent: false,
-  frame: false,
   show: false,
   vibrancy: 'window',
   visualEffectState: 'followWindow',

--- a/main.js
+++ b/main.js
@@ -40,6 +40,7 @@ const menuTemplate = [
       { role: 'togglefullscreen' },
       {
         label: 'Toggle Sidebar',
+        accelerator: 'CommandOrControl+B',
         id: 'toggleSidebar',
         click(menuItem, window, event) {
           mainWindow.webContents.send('toggleSidebar');


### PR DESCRIPTION
- Windows and Linux both have the frame I don't see why macOS should be different
- allows window management with the sidebar closed
- restores functionality of the arrangement buttons on macOS
- add shortcut Ctrl+B to toggle sidebar

This closes #282 and #281 